### PR TITLE
fix: conflicting license information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = kimmdy-grappa
 version = 0.3.2
-license = MIT
+license = GPL-3.0 
 description = Parameterization interface between KIMMDY and GrAPPa
 description_content_type = text/markdown
 long_description = file: README.md
@@ -10,7 +10,6 @@ author = Eric Hartmann
 author_email = eric.hartmann@h-its.org
 classifiers=
         Programming Language :: Python :: 3
-        License :: OSI Approved :: MIT License
         Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
The classifier is deprecated, and not compatible with having a `license` string. The license file was GPL, while the text said MIT. As KIMMDY is GPL, this should also be GPL.